### PR TITLE
adds page title (#2), and makes friends logos responsive to fix mobil…

### DIFF
--- a/Views/Master.cshtml
+++ b/Views/Master.cshtml
@@ -20,7 +20,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/bodymovin/5.5.2/lottie.min.js" integrity="sha256-G8zbnVrieJloV/OI6KCIpVKvP5uWGxqJ59/Z7w/MhAA=" crossorigin="anonymous"></script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>@Model.Value("websiteTitle", fallback: Fallback.ToAncestors)</title>
+    <title>@Model.Value("pageTitle", fallback: Fallback.ToAncestors)</title>
     @{
     var socialImage = Model.Value<IPublishedContent>("socialImage", fallback: Fallback.ToAncestors);
     var metaDescription = Model.Value<string>("metaDescription");

--- a/wwwroot/static/css/modules/friends.scss
+++ b/wwwroot/static/css/modules/friends.scss
@@ -1,6 +1,12 @@
 .friends {
   display: flex;
-  flex-flow: row nowrap;
+  flex-flow: row wrap;
   align-items: center;
   justify-content: center;
+  gap: 2rem;
+
+  img {
+	max-width: 100%;
+	height: auto;
+  }
 }


### PR DESCRIPTION
# #2 uses the `pageTitle` property as the value for the `<title>` tag.

<img width="719" alt="image" src="https://user-images.githubusercontent.com/713355/177919599-620a00e4-664c-4bf4-9f82-9da27c6bb611.png">


# Makes the logo area under "Friends of H5YR" responsive. This was breaking the layout on mobile devices.

<img width="207" alt="image" src="https://user-images.githubusercontent.com/713355/177919494-3e8969ad-06ed-4ec3-b466-2c4854db5b17.png">
