### PR TITLE
Change main CTA to a toot with a link to prefill with a hashtag of H5YR

### DIFF
--- a/Views/Home.cshtml
+++ b/Views/Home.cshtml
@@ -35,11 +35,8 @@
                     @Model.BodyText
                 }
                 <div class="[ button-holder -margin-top ]">
-                    <a class="[ button -icon-left ]" href="https://twitter.com/intent/tweet?hashtags=H5YR">
-                        <svg class="[ icon icon--button-twitter ]">
-                            <use xlink:href="#sprite-icon-twitter"></use>
-                        </svg>
-                        <span>Tweet a high five</span>
+                    <a class="[ button -icon-left ]" href="https://umbracocommunity.social/share?text=#H5YR">
+                        <span>Toot a high five</span>
                     </a>
                 </div>
             </div>


### PR DESCRIPTION
Change main CTA to a toot with a link to prefill with a hashtag of H5YR and removed twitter icon from markup
Note: only will work for users on `umbracocommunity.social` which most of the community seem's to be

![image](https://github.com/H5YR/High5YouRock/assets/1389894/669a3c3d-dd9a-46da-bf6d-8bfd263feba7)
