### PR TITLE
Use a different tag name for staging builds

### DIFF
--- a/.github/workflows/STAGING.yml
+++ b/.github/workflows/STAGING.yml
@@ -85,4 +85,4 @@ jobs:
           uses: tvdias/github-tagger@v0.0.1
           with:
             repo-token: ${{ secrets.GITHUB_TOKEN }}
-            tag: ProductionBuild-${{ steps.date.outputs.year }}${{ steps.date.outputs.month }}${{ steps.date.outputs.day }}-${{ github.run_number }}
+            tag: StagingBuild-${{ steps.date.outputs.year }}${{ steps.date.outputs.month }}${{ steps.date.outputs.day }}-${{ github.run_number }}


### PR DESCRIPTION
Fix for #40, prevents trying to add duplicate tag names.

It might also be helpful to append `run_attempt` in order to avoid duplicating on re-runs  - what's the main reason for the tags @OwainWilliams?