### PR TITLE
Add caching for Mastodon posts - #22

### DIFF
--- a/Core/Services/IMastodonService.cs
+++ b/Core/Services/IMastodonService.cs
@@ -4,6 +4,6 @@ namespace h5yr.Core.Services
 {
     public interface IMastodonService
     {
-        Task<IReadOnlyList<MastodonStatus>> GetStatuses(int limit, string? maxId = null);
+        Task<List<MastodonStatus>> GetStatuses(int limit);
     }
 }


### PR DESCRIPTION
Fixes #22 

Have added in some caching for Mastodon Posts. At the core it is following a similar approach to what they've done on Our using the Umbraco RuntimeCache, but with a few differences to work better with the existing H5YR code.

* Works with the async method headers, though I've taken out the MaxId parameter from both interface and implementation as this seemed to be completely unused anyway.
* Changed IReadOnlyList to List. They broadly work the same, but List is a bit easier to declare empty versions of for if loading from the API has failed.
* Most of the hardcoded text/strings have been moved to constants at the top, all named 'FeedSomething'. These could have been moved out completely into appsettings, but for something which will rarely change thought that might be overkill. This at least keeps them all at the top of the cs file though for easier changes in future rather than needing to find them in the middle of the code.
* Caching has been set using this to 15 minutes, as I thought an hour might be a bit too infrequent. But this value can easily be played with up or down anyway depending on results. As all the posts are pushed to Umbraco's Cache too, it's possible for an admin to override the cache and force a reload by publishing something from Back Office anyway.