### PR TITLE
Added in custom emoji support for the Umbraco Community server

### DIFF
--- a/Core/Extensions/StringExtensions.cs
+++ b/Core/Extensions/StringExtensions.cs
@@ -1,0 +1,18 @@
+﻿using h5yr.ViewComponents;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace h5yr.Core.Extensions
+{
+    public static class StringExtensions
+    {
+        public static string ReplaceCustomEmojis(this string text, IReadOnlyList<MastodonCustomEmoji> customEmojis)
+        {
+            foreach (var emoji in customEmojis)
+            {
+                text = text.Replace($":{emoji.Shortcode}:", $"<img src='{emoji.Url}' alt='{emoji.Shortcode}' title='{emoji.Shortcode}' class='inline_emoji' />");
+            }
+
+            return text;
+        }
+    }
+}

--- a/Core/Services/IMastodonService.cs
+++ b/Core/Services/IMastodonService.cs
@@ -1,9 +1,12 @@
-﻿using Skybrud.Social.Mastodon.Models.Statuses;
+﻿using h5yr.ViewComponents;
+using Skybrud.Social.Mastodon.Models.Statuses;
 
 namespace h5yr.Core.Services
 {
     public interface IMastodonService
     {
         Task<List<MastodonStatus>> GetStatuses(int limit);
+
+        Task<List<MastodonCustomEmoji>> GetCustomEmojis();
     }
 }

--- a/MastodonCustomEmojis.json
+++ b/MastodonCustomEmojis.json
@@ -1,0 +1,50 @@
+[
+  {
+    "shortcode": "dteam",
+    "url": "https://cdn.masto.host/umbracocommunitysocial/custom_emojis/images/000/006/957/original/41faca235db8cb87.png",
+    "static_url": "https://cdn.masto.host/umbracocommunitysocial/custom_emojis/images/000/006/957/static/41faca235db8cb87.png",
+    "visible_in_picker": true
+  },
+  {
+    "shortcode": "h5yr",
+    "url": "https://cdn.masto.host/umbracocommunitysocial/custom_emojis/images/000/006/954/original/4d5df48132c2afec.png",
+    "static_url": "https://cdn.masto.host/umbracocommunitysocial/custom_emojis/images/000/006/954/static/4d5df48132c2afec.png",
+    "visible_in_picker": true
+  },
+  {
+    "shortcode": "mvp",
+    "url": "https://cdn.masto.host/umbracocommunitysocial/custom_emojis/images/000/006/958/original/ad7104486df5d63c.png",
+    "static_url": "https://cdn.masto.host/umbracocommunitysocial/custom_emojis/images/000/006/958/static/ad7104486df5d63c.png",
+    "visible_in_picker": true
+  },
+  {
+    "shortcode": "rune",
+    "url": "https://cdn.masto.host/umbracocommunitysocial/custom_emojis/images/000/006/959/original/c6339a718b34120e.png",
+    "static_url": "https://cdn.masto.host/umbracocommunitysocial/custom_emojis/images/000/006/959/static/c6339a718b34120e.png",
+    "visible_in_picker": true
+  },
+  {
+    "shortcode": "umbraco",
+    "url": "https://cdn.masto.host/umbracocommunitysocial/custom_emojis/images/000/006/400/original/69c87d06bab42480.png",
+    "static_url": "https://cdn.masto.host/umbracocommunitysocial/custom_emojis/images/000/006/400/static/69c87d06bab42480.png",
+    "visible_in_picker": true
+  },
+  {
+    "shortcode": "umbracoheart",
+    "url": "https://cdn.masto.host/umbracocommunitysocial/custom_emojis/images/000/006/955/original/8466492895637c14.png",
+    "static_url": "https://cdn.masto.host/umbracocommunitysocial/custom_emojis/images/000/006/955/static/8466492895637c14.png",
+    "visible_in_picker": true
+  },
+  {
+    "shortcode": "umbracopackage",
+    "url": "https://cdn.masto.host/umbracocommunitysocial/custom_emojis/images/000/006/956/original/4e6d7e5996c5ffd4.png",
+    "static_url": "https://cdn.masto.host/umbracocommunitysocial/custom_emojis/images/000/006/956/static/4e6d7e5996c5ffd4.png",
+    "visible_in_picker": true
+  },
+  {
+    "shortcode": "umbracospark",
+    "url": "https://cdn.masto.host/umbracocommunitysocial/custom_emojis/images/000/006/401/original/e9748ac3e45c3b4b.png",
+    "static_url": "https://cdn.masto.host/umbracocommunitysocial/custom_emojis/images/000/006/401/static/e9748ac3e45c3b4b.png",
+    "visible_in_picker": true
+  }
+]

--- a/ViewComponents/MastodonCustomEmoji.cs
+++ b/ViewComponents/MastodonCustomEmoji.cs
@@ -1,0 +1,24 @@
+﻿using Skybrud.Social.Mastodon.Models.Statuses;
+using System.Text.Json.Serialization;
+
+namespace h5yr.ViewComponents;
+
+public class MastodonCustomEmoji {
+
+    /// <summary>
+    /// Based off json model from:- https://docs.joinmastodon.org/methods/custom_emojis/
+    /// </summary>
+    public string? Shortcode { get; set; }
+
+    public string? Url { get; set; }
+
+    [JsonPropertyName("static_url")]
+
+    public string? StaticUrl { get; set; }
+
+    [JsonPropertyName("visible_in_picker")]
+    public bool? VisibleInPicker { get; set; }
+
+    public string? Category { get; set; }
+
+}

--- a/ViewComponents/MastodonModel.cs
+++ b/ViewComponents/MastodonModel.cs
@@ -6,8 +6,12 @@ public class MastodonModel {
 
     public IReadOnlyList<MastodonStatus> Statuses { get; }
 
-    public MastodonModel(IReadOnlyList<MastodonStatus> statuses) {
+    public IReadOnlyList<MastodonCustomEmoji> CustomEmojis { get; }
+
+    public MastodonModel(IReadOnlyList<MastodonStatus> statuses, IReadOnlyList<MastodonCustomEmoji> customEmojis)
+    {
         Statuses = statuses;
+        CustomEmojis = customEmojis;
     }
 
 }

--- a/ViewComponents/MastodonViewComponent.cs
+++ b/ViewComponents/MastodonViewComponent.cs
@@ -28,8 +28,11 @@ public class MastodonViewComponent : ViewComponent {
         // Get the statuses
         IReadOnlyList<MastodonStatus> statuses = await GetStatuses();
 
+        // Get the custom emojis
+        IReadOnlyList<MastodonCustomEmoji> customEmojis = await _mastodonService.GetCustomEmojis();
+
         // Initialize a new model for the view component
-        MastodonModel model = new(statuses);
+        MastodonModel model = new(statuses, customEmojis);
 
         // Return the view
         return View(model);

--- a/Views/Shared/Components/Mastodon/Default.cshtml
+++ b/Views/Shared/Components/Mastodon/Default.cshtml
@@ -1,4 +1,5 @@
 ﻿@using Skybrud.Social.Mastodon.Models.Statuses
+@using h5yr.Core.Extensions
 
 @model h5yr.ViewComponents.MastodonModel
 
@@ -27,7 +28,7 @@
                             </a>
                         </div>
                         <div class="tweet__content">
-                            @Html.Raw(status.Content)
+                            @Html.Raw(status.Content.ReplaceCustomEmojis(Model.CustomEmojis))
                         </div>
                     </div>
                     <p></p>

--- a/frontend/css/modules/tweets.scss
+++ b/frontend/css/modules/tweets.scss
@@ -100,6 +100,13 @@
     word-break: break-word;
     text-decoration: none;
   }
+  
+  .inline_emoji
+  {
+	height: 1.3rem;
+	vertical-align: middle;
+  }
+  
 }
 
 .tweet__actions {


### PR DESCRIPTION
When on Mastodon you can insert some custom shortcodes like :h5yr: and :umbraco: in a toot and they'll be replaced with image icons when on the Mastodon site/app. This adds the same support in to replace the tags on h5yr too.

Currently this is based off a static download of the custom emoji list which has been saved locally in 'MastodonCustomEmojis.json', so just make sure this file goes out with any deployment. Ideally this hardcoded file will be swapped out with a version which pulls this list in directly from the API instead so they are always kept uptodate if new ones are added in the future, but I decided this is a feature probably better added in to the Skybrud plugin instead as it would then be useable anywhere else which uses this nuget package. But that can come later. For now it has been written in such a way in this project that it should be possible to swap this out in the 'LoadCustomEmojis' method with a different implementation/model later.

(Sorry, I had actually meant to implement this one during Hacktoberfest, but as the project was in a bit more of a state of flux at the time due to the frontend reimplementation in Vite, I left it and then forgot all about it. Hopefully better late than never!)